### PR TITLE
Divide alpha by n in LRN layer

### DIFF
--- a/customlayers.py
+++ b/customlayers.py
@@ -19,7 +19,7 @@ def crosschannelnormalization(alpha = 1e-4, k=2, beta=0.75, n=5,**kwargs):
         extra_channels = K.permute_dimensions(extra_channels, (0,3,1,2))
         scale = k
         for i in xrange(n):
-            scale += alpha * extra_channels[:,i:i+ch,:,:]
+            scale += alpha / n * extra_channels[:,i:i+ch,:,:]
         scale = scale ** beta
         return X / scale
 


### PR DESCRIPTION
Hi,

your implementation of the LRN layer seems to be based on [this implementation](https://github.com/MarcBS/keras/blob/master/keras/caffe/extra_layers.py) of the local response normalization layer. It contains a bug in comparison to Caffe: alpha is not divided by n as it [should be](https://github.com/BVLC/caffe/blob/master/src/caffe/layers/lrn_layer.cpp#L120). That would be fixed with this pull request.