### PR TITLE
Fixing color order in preprocess_image_batch

### DIFF
--- a/convnetskeras/convnets.py
+++ b/convnetskeras/convnets.py
@@ -289,13 +289,13 @@ def preprocess_image_batch(image_paths, img_size=None, crop_size=None, color_mod
             img = imresize(img,img_size)
 
         img = img.astype('float32')
-        # We permute the colors to get them in the BGR order
-        if color_mode=="bgr":
-            img[:,:,[0,1,2]] = img[:,:,[2,1,0]]
-        # We normalize the colors with the empirical means on the training set
+        # We normalize the colors (in RGB space) with the empirical means on the training set
         img[:, :, 0] -= 123.68
         img[:, :, 1] -= 116.779
         img[:, :, 2] -= 103.939
+        # We permute the colors to get them in the BGR order
+        if color_mode=="bgr":
+            img[:,:,[0,1,2]] = img[:,:,[2,1,0]]
         img = img.transpose((2, 0, 1))
 
         if crop_size:


### PR DESCRIPTION
In function preprocess_image_batch (convnetskeras/convnets.py), color normalization is done (in RGB space as before) before possible color permutation to BGR.